### PR TITLE
Add setup ROS env to 00-create-cd.sh

### DIFF
--- a/00-create-cd.sh
+++ b/00-create-cd.sh
@@ -96,6 +96,11 @@ apt-get -y install ros-$ROSDISTRO-turtlebot-apps
 apt-get -y install ros-$ROSDISTRO-turtlebot
 fi
 
+# set ROS environment
+touch ~/.bashrc
+echo "source /opt/ros/hydro/setup.bash" >> ~/.bashrc
+source ~/.bashrc
+
 # install emacs
 apt-get -y install emacs
 


### PR DESCRIPTION
moved from #1
https://github.com/tork-a/live-cd/pull/19
で
```
そもそもは，livecdもインストールした直後もsetup.bashが呼ばれないので，

echo "source /opt/ros/hydro/setup.bash" >> ~/.bashrc
するひつようがありますが，デフォルトで.bashrcに source /opt/ros/hydro/setup.bashを書いてもいいかなぁ，
と
思ったんですが，そうすると世の中に出回っているマニュアル／チュートリアルとは状況が異なる
のでダメかなという判断です．

がよく考えるとsource してある状況でマニュアルをみて
echo "source /opt/ros/hydro/setup.bash" >> ~/.bashrc
しても問題はない，ということもいえるかもしれないです．どうでしょうかね．
```
と書いたのは既に
https://github.com/tork-a/live-cd/pull/1
にありましたね．
skelに書いておくと，cdからインストールしたひとにも恩恵があったりしますでしょうか．