### PR TITLE
fix slow boot

### DIFF
--- a/00-create-cd.sh
+++ b/00-create-cd.sh
@@ -187,7 +187,6 @@ favorites=\`gsettings get com.canonical.Unity.Launcher favorites\`
 ## recompile schemas file
 glib-compile-schemas /usr/share/glib-2.0/schemas/
 
-
 ## write test code
 if [ ! -e /home/ubuntu/.live-cd-test.sh ]; then
   echo "`cat dot-live-cd-test.sh`" >> /home/ubuntu/.live-cd-test.sh
@@ -206,6 +205,12 @@ if [ ! ${DEBUG} ]; then
     sudo cp -r ~/tmp/remaster-apt-cache/archives ~/tmp/remaster-iso/repository/binary
     sudo chmod a+rx ~/tmp/remaster-iso/repository/binary/
     sudo su -c "cd ${HOME}/tmp/remaster-iso/repository/; dpkg-scanpackages binary /dev/null | gzip -9c > binary/Packages.gz"
+    ## update boot option
+    sudo su -c "cd ${HOME}/tmp/remaster-iso/isolinux; sed -i 's/quiet splash//' txt.cfg"
+    sudo su -c "cd ${HOME}/tmp/remaster-iso/isolinux; sed -i 's/^/#/' isolinux.cfg"
+    sudo su -c "cd ${HOME}/tmp/remaster-iso/isolinux; echo 'include txt.cfg' >> isolinux.cfg"
+
+
     # create iso
     DATE=`date +%Y%m%d`
     FILENAME=tork-ubuntu-ros-${REV}-amd64-${DATE}.iso


### PR DESCRIPTION
DO NOT MERGE YET

after testing on several setups, I found that the problem depends on not usb disk, but the computer its self.

My guess is that the USB boots very fast with UEFI system, but very slow on old BIOS system. I confirmed this on t430s and t400s.

Workarounds for this situation is
- disable quiet boot
- disable ipv6
- remove aptdaeomn
and if I set all of them, it boot within a 2-3 min. I'm not sure if we need all of them. I'll check detailed condition on this PR.

```
net.ipv6.conf.all.disable_ipv6 = 1                                                             
net.ipv6.conf.default.disable_ipv6 = 1                                                         
net.ipv6.conf.lo.disable_ipv6 = 1                                                              
" >> /etc/sysctl.conf                                                                          
                                                                                               
oacpi"/' /etc/default/grub                                                                     
                                                                                               
apt-get -y remove aptdaemon   
```